### PR TITLE
Added 'quiet' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,11 @@ Default value: `'autocommit'`
 
 Commit message.
 
+#### options.quiet
+Type: `Boolean`
+Default value: `true`
+
+Suppress git console output, including output from remote server when pushing.
+
 ## Contributing
 If you can think of a way to unit test this plugin please take a shot at it.


### PR DESCRIPTION
I've added an additional config option, mainly to read Git hooks output from remote servers.