### PR TITLE
Support tagging of commits

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -93,6 +93,7 @@ module.exports = function(grunt) {
       first: {
         options: {
           url: '../repo',
+          tag: 'v1',
           message: 'first deploy'
         },
         src: 'tmp/src'
@@ -100,6 +101,7 @@ module.exports = function(grunt) {
       second: {
         options: {
           url: '../repo',
+          tag: 'v2',
           message: 'second deploy'
         },
         src: 'tmp/src'

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Deploy files to any branch of any remote git repository.
 
 ## Getting Started
-This plugin requires Grunt `~0.4.1`
+This plugin requires Grunt `~0.4.1` and must be used with Git `1.8.3` or better (see [Git changelog](https://github.com/git/git/blob/master/Documentation/RelNotes/1.8.3.txt#L155-L156)).
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
@@ -55,6 +55,26 @@ Type: `String`
 Default value: `'autocommit'`
 
 Commit message.
+
+#### options.tag
+Type: `Boolean`/`String`
+Default value: `false`
+
+Whether to tag the release. Provide a tag name (string) to tag the release commit. To use the package version, first 
+read the package.json 
+
+    grunt.initConfig({
+      pkg: grunt.file.readJSON("package.json")
+      ...
+    })
+    
+and then pass the value `'<%= pkg.version %>'`
+
+#### options.tagMessage
+Type: `String`
+Default value: `'autocommit'`
+
+The message for the tag referenced above. This option is ignored if `options.tag` is `false`.
 
 ## Contributing
 If you can think of a way to unit test this plugin please take a shot at it.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-git-deploy",
   "description": "Deploy files to any branch of any remote git repository.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "homepage": "https://github.com/iclanzan/grunt-git-deploy",
   "author": {
     "name": "Sorin Iclanzan",

--- a/tasks/git_deploy.js
+++ b/tasks/git_deploy.js
@@ -18,6 +18,8 @@ module.exports = function(grunt) {
     // Merge task options with these defaults.
     var options = this.options({
       message: 'autocommit',
+      tag: false,
+      tagMessage: 'autocommit',
       branch: 'gh-pages'
     });
 
@@ -95,14 +97,21 @@ module.exports = function(grunt) {
 
     var done = this.async();
 
-    grunt.util.async.series([
+    var commands = [
       git(['clone', '-b', options.branch, options.url, '.' ]),
       git(['checkout', '-B', options.branch]),
       copyIntoRepo( src, deployDir ),
       git(['add', '--all']),
-      git(['commit', '--message=' + options.message]),
-      git(['push', '--prune', '--quiet', options.url, options.branch])
-    ], done);
+      git(['commit', '--message=' + options.message ])
+    ];
+
+    if ( options.tag ) {
+      commands.push( git(['tag', '-a', options.tag, '-m', options.tagMessage]) );
+    }
+
+    commands.push( git(['push', '--prune', '--force', '--quiet', '--follow-tags', options.url, options.branch]) );
+
+    grunt.util.async.series(commands, done);
 
   });
 };

--- a/test/git_deploy_test.js
+++ b/test/git_deploy_test.js
@@ -32,7 +32,7 @@ exports.git_deploy = {
     }, done);
   },
   default_options: function(test) {
-    test.expect(7);
+    test.expect(6);
 
     grunt.file.recurse('test/fixtures/second', function(abs, root, subdir, file) {
       var relativePath = path.join(subdir || '', file);
@@ -40,16 +40,19 @@ exports.git_deploy = {
     });
 
     test.ok(!grunt.file.exists(path.join('tmp/repo', 'to-be-removed')), 'The file ‘to-be-removed’ should have been removed from the repository.');
+    test.done();
+  },
 
+  commit_message: function(test) {
+    test.expect(1);
     grunt.util.spawn({
       cmd: 'git',
       args: ['log', '--format=%s'],
       opts: {cwd: 'tmp/repo'}
-    }, function( a, b, c ){
+    }, function(error, result, code){
       //Get repo history
       var expected = "second deploy\nfirst deploy\nInitial commit";
-      test.equal( b.stdout, expected, 'The deployment repository`s history is not as expected' )
-
+      test.equal( result.stdout, expected, 'The deployment repository`s history is not as expected' )
       test.done();
     } );
 

--- a/test/git_deploy_test.js
+++ b/test/git_deploy_test.js
@@ -56,5 +56,19 @@ exports.git_deploy = {
       test.done();
     } );
 
-  }
+  },
+
+  tags: function(test) {
+    test.expect(1);
+    grunt.util.spawn({
+      cmd: 'git',
+      args: ['tag'],
+      opts: {cwd: 'tmp/repo'}
+    },function( error, result, code ){
+      //Get repo history
+      var expected = "v1\nv2";
+      test.equal( result.stdout, expected, 'The deployment repository`s tags are not as expected' )
+      test.done();
+    });
+  },
 };


### PR DESCRIPTION
This PR adds `tag` and `tagMessage` options. Default behaviour remains unchanged, but by specifying a tag and tagMessage, these will be applied to the commit in the release repository.

However, it uses `--follow-tags` which requires Git 1.8.3. Compatibility with older versions of Git would be possible though.

Adds a unit test & documentation for the new feature.

As an example of tagging the commit with the version specified in `package.json`:

```js
grunt.initConfig({
  git_deploy: {
    your_target: {
      options: {
        url: 'git@github.com:example/repo.git',
        tag: '<%= pkg.version %>',
        tagMessage: 'v<%= pkg.version %>'
      },
      src: 'directory/to/deploy'
    },
  },
})
```