### PR TITLE
Do not attempt deploy without changes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,6 +105,14 @@ module.exports = function(grunt) {
           message: 'second deploy'
         },
         src: 'tmp/src'
+      },
+      null_deploy: {
+        options: {
+          url: '../repo',
+          tag: 'null',
+          message: 'null deploy, should not work'
+        },
+        src: 'tmp/src'
       }
     },
 
@@ -125,7 +133,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'init_repo', 'copy:first', 'git_deploy:first', 'clean:deploy', 'clean:test_build', 'copy:second', 'git_deploy:second', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'init_repo', 'copy:first', 'git_deploy:first', 'clean:deploy', 'clean:test_build', 'copy:second', 'git_deploy:second', 'clean:deploy', 'clean:test_build', 'copy:second', 'git_deploy:null_deploy', 'nodeunit']);
 
   // By default, run all tests.
   grunt.registerTask('default', ['test']);


### PR DESCRIPTION
Currently, grunt-git-deploy fails with a nondescript error if there are no changes to be committed:

```
Running "git_deploy:null_deploy" (git_deploy) task
>> Cannot delete nonexistent file.
Running clone -b gh-pages ../repo . in tmp/grunt-git-deploy
Running checkout -B gh-pages in tmp/grunt-git-deploy
Copying tmp/src to tmp/grunt-git-deploy
>> Cannot delete nonexistent file.
Running add --all in tmp/grunt-git-deploy
Running commit --message=null deploy, should not work in tmp/grunt-git-deploy
Warning:  Use --force to continue.

Aborted due to warnings.
```

This change instead makes it log out an informational message and proceed, by first running `git status` to see if any files have changed:

```
Running "git_deploy:null_deploy" (git_deploy) task
>> Cannot delete nonexistent file.
Running clone -b gh-pages ../repo . in tmp/grunt-git-deploy
Running checkout -B gh-pages in tmp/grunt-git-deploy
Copying tmp/src to tmp/grunt-git-deploy
>> Cannot delete nonexistent file.
Nothing for git_deploy to commit.

Done.
```
